### PR TITLE
Pass the overrides to the ContextBuilder

### DIFF
--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/UploadLargeObject.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/UploadLargeObject.java
@@ -76,6 +76,7 @@ public class UploadLargeObject implements Closeable {
       
       BlobStoreContext context = ContextBuilder.newBuilder(provider)
             .credentials(username, apiKey)
+            .overrides(overrides)
             .buildView(BlobStoreContext.class);
       storage = context.getBlobStore();
    }


### PR DESCRIPTION
Previously the overrides were not actually used.
