### PR TITLE
Revert RestContext from Examples

### DIFF
--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/CreateVolumeAndAttach.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/CreateVolumeAndAttach.java
@@ -48,9 +48,11 @@ import org.jclouds.openstack.cinder.v1.features.VolumeApi;
 import org.jclouds.openstack.cinder.v1.options.CreateVolumeOptions;
 import org.jclouds.openstack.cinder.v1.predicates.VolumePredicates;
 import org.jclouds.openstack.nova.v2_0.NovaApi;
+import org.jclouds.openstack.nova.v2_0.NovaAsyncApi;
 import org.jclouds.openstack.nova.v2_0.domain.VolumeAttachment;
 import org.jclouds.openstack.nova.v2_0.domain.zonescoped.ZoneAndId;
 import org.jclouds.openstack.nova.v2_0.extensions.VolumeAttachmentApi;
+import org.jclouds.rest.RestContext;
 import org.jclouds.scriptbuilder.ScriptBuilder;
 import org.jclouds.scriptbuilder.domain.OsFamily;
 import org.jclouds.sshj.config.SshjSshClientModule;
@@ -67,8 +69,9 @@ import com.google.inject.Module;
  */
 public class CreateVolumeAndAttach implements Closeable {
    private final ComputeService computeService;
-   private final NovaApi nova;
+   private final RestContext<NovaApi, NovaAsyncApi> nova;
    private final VolumeAttachmentApi volumeAttachmentApi;
+
    private final CinderApi cinderApi;
    private final VolumeApi volumeApi;
 
@@ -107,14 +110,14 @@ public class CreateVolumeAndAttach implements Closeable {
 
       Iterable<Module> modules = ImmutableSet.<Module> of(new SshjSshClientModule());
 
-      ContextBuilder builder = ContextBuilder.newBuilder(provider)
+      ComputeServiceContext context = ContextBuilder.newBuilder(provider)
             .credentials(username, apiKey)
             .modules(modules)
-            .overrides(overrides);
-
-      computeService = builder.buildView(ComputeServiceContext.class).getComputeService();
-      nova = builder.buildApi(NovaApi.class);
-      volumeAttachmentApi = nova.getVolumeAttachmentExtensionForZone(ZONE).get();
+            .overrides(overrides)
+            .buildView(ComputeServiceContext.class);
+      computeService = context.getComputeService();
+      nova = context.unwrap();
+      volumeAttachmentApi = nova.getApi().getVolumeAttachmentExtensionForZone(ZONE).get();
 
       cinderApi = ContextBuilder.newBuilder(PROVIDER)
             .credentials(username, apiKey)
@@ -137,7 +140,7 @@ public class CreateVolumeAndAttach implements Closeable {
       String publicAddress = nodeMetadata.getPublicAddresses().iterator().next();
 
       // We set the password to something we know so we can login in the DetachVolume example
-      nova.getServerApiForZone(ZONE)
+      nova.getApi().getServerApiForZone(ZONE)
             .changeAdminPass(nodeMetadata.getProviderId(), PASSWORD);
 
       System.out.format("  %s%n", nodeMetadata);
@@ -215,7 +218,6 @@ public class CreateVolumeAndAttach implements Closeable {
     */
    public void close() throws IOException {
       Closeables.close(cinderApi, true);
-      Closeables.close(nova, true);
       Closeables.close(computeService.getContext(), true);
    }
 }

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/DetachVolume.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/DetachVolume.java
@@ -39,11 +39,13 @@ import org.jclouds.openstack.cinder.v1.domain.Volume;
 import org.jclouds.openstack.cinder.v1.features.VolumeApi;
 import org.jclouds.openstack.cinder.v1.predicates.VolumePredicates;
 import org.jclouds.openstack.nova.v2_0.NovaApi;
+import org.jclouds.openstack.nova.v2_0.NovaAsyncApi;
 import org.jclouds.openstack.nova.v2_0.domain.Server;
 import org.jclouds.openstack.nova.v2_0.domain.VolumeAttachment;
 import org.jclouds.openstack.nova.v2_0.domain.zonescoped.ZoneAndId;
 import org.jclouds.openstack.nova.v2_0.extensions.VolumeAttachmentApi;
 import org.jclouds.openstack.nova.v2_0.features.ServerApi;
+import org.jclouds.rest.RestContext;
 import org.jclouds.scriptbuilder.ScriptBuilder;
 import org.jclouds.scriptbuilder.domain.OsFamily;
 import org.jclouds.sshj.config.SshjSshClientModule;
@@ -60,7 +62,7 @@ import com.google.inject.Module;
  */
 public class DetachVolume implements Closeable {
    private final ComputeService computeService;
-   private final NovaApi nova;
+   private final RestContext<NovaApi, NovaAsyncApi> nova;
    private final ServerApi serverApi;
    private final VolumeAttachmentApi volumeAttachmentApi;
 
@@ -97,13 +99,14 @@ public class DetachVolume implements Closeable {
 
       Iterable<Module> modules = ImmutableSet.<Module> of(new SshjSshClientModule());
 
-      ContextBuilder builder = ContextBuilder.newBuilder(provider)
+      ComputeServiceContext context = ContextBuilder.newBuilder(provider)
             .credentials(username, apiKey)
-            .modules(modules);
-      computeService = builder.buildView(ComputeServiceContext.class).getComputeService();
-      nova = builder.buildApi(NovaApi.class);
-      serverApi = nova.getServerApiForZone(ZONE);
-      volumeAttachmentApi = nova.getVolumeAttachmentExtensionForZone(ZONE).get();
+            .modules(modules)
+            .buildView(ComputeServiceContext.class);
+      computeService = context.getComputeService();
+      nova = context.unwrap();
+      serverApi = nova.getApi().getServerApiForZone(ZONE);
+      volumeAttachmentApi = nova.getApi().getVolumeAttachmentExtensionForZone(ZONE).get();
 
       cinderApi = ContextBuilder.newBuilder(PROVIDER)
             .credentials(username, apiKey)
@@ -177,7 +180,6 @@ public class DetachVolume implements Closeable {
     */
    public void close() throws IOException {
       Closeables.close(cinderApi, true);
-      Closeables.close(nova, true);
       Closeables.close(computeService.getContext(), true);
    }
 }


### PR DESCRIPTION
This PR is to revert the Rackspace Compute and Block Storage examples that were changed in PR https://github.com/jclouds/jclouds-examples/pull/35. Until Nova is unasynced, the example code will need to continue utilizing RestContext.

The reverted examples have been tested against the live endpoint. 
