### PR TITLE
Remove trailing whitespace

### DIFF
--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/Authentication.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/Authentication.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -30,14 +30,14 @@ import org.jclouds.openstack.nova.v2_0.NovaApi;
 import com.google.common.io.Closeables;
 
 /**
- * To authenticate using jclouds you need to provide your credentials to a Context as in the init() method below. 
- * Authentication occurs on your first actual interaction with the Rackspace Cloud (i.e. the very first time 
+ * To authenticate using jclouds you need to provide your credentials to a Context as in the init() method below.
+ * Authentication occurs on your first actual interaction with the Rackspace Cloud (i.e. the very first time
  * you call a method that needs to talk to the cloud). Once you are authenticated you receive a token that is
  * cached and you won't reauthenticate for subsequent calls. If your token expires before the JVM quits, jclouds
  * will automatically handle reauthentication and get a new token for you.
- * 
+ *
  * If authentication doesn't work, the call will result in an org.jclouds.rest.AuthorizationException
- * 
+ *
  * This example demostrates how you would authenticate via username and password or API key. The default is
  * authentication via API key, which is used in the rest of the examples in this package.
  */
@@ -46,10 +46,10 @@ public class Authentication implements Closeable {
 
     /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key or password
-    * [Optional] The third argument (args[2]) must be "password" if password authentication is used, 
+    * [Optional] The third argument (args[2]) must be "password" if password authentication is used,
     *            otherwise default to using API key.
     */
    public static void main(String[] args) throws IOException {

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/Logging.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/Logging.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -33,11 +33,11 @@ import com.google.inject.Module;
 /**
  * This example shows you how to log what jclouds is doing. This is extremely useful for debugging, submitting bug
  * reports, getting help, and figuring exactly what the HTTP requests and resonses look like.
- * 
+ *
  * In this example we use the Simple Logging Facade for Java (SLF4J). The implementation of SLF4J that we'll use is
  * Logback so you'll need to download the Logback JARs from http://logback.qos.ch/download.html and put them on your
  * classpath.
- * 
+ *
  * The last key ingredient is the file /jclouds-examples/rackspace/src/main/resources/logback.xml which configures
  * the logging. As it is configured right now it will log wire input/output and headers to standard out (STDOUT).
  * This means that you will be able to see on your console everything that is sent in the request (marked by ">>")
@@ -48,7 +48,7 @@ public class Logging implements Closeable {
 
     /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -77,7 +77,7 @@ public class Logging implements Closeable {
       nova = ContextBuilder.newBuilder(provider)
             .credentials(username, apiKey)
             .modules(modules) // don't forget to add the modules to your context!
-            .buildApi(NovaApi.class); 
+            .buildApi(NovaApi.class);
    }
 
    private void getConfiguredZones() {

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/SmokeTest.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/SmokeTest.java
@@ -39,7 +39,7 @@ public class SmokeTest {
    /**
     * To get a username and API key see
     * http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/autoscale/AutoscaleCleanup.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/autoscale/AutoscaleCleanup.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -89,7 +89,7 @@ public class AutoscaleCleanup implements Closeable {
 
                if (!(p.getTarget().equals("0") && p.getTargetType().equals(ScalingPolicyTargetType.DESIRED_CAPACITY))) {
                   System.out.format("Removing servers %n");
-                  
+
                   // Update policy to 0 servers
                   CreateScalingPolicy scalingPolicy = CreateScalingPolicy.builder()
                         .cooldown(3)
@@ -98,10 +98,10 @@ public class AutoscaleCleanup implements Closeable {
                         .targetType(ScalingPolicyTargetType.DESIRED_CAPACITY)
                         .target("0")
                         .build();
-   
+
                   pa.update(policyId, scalingPolicy);
                   Uninterruptibles.sleepUninterruptibly(5, TimeUnit.SECONDS);
-   
+
                   try {
                      pa.execute(policyId);
                   } catch (Exception e) {
@@ -116,7 +116,7 @@ public class AutoscaleCleanup implements Closeable {
             }
          }
       }
-      
+
    }
 
    /**

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/autoscale/Constants.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/autoscale/Constants.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/autoscale/CreatePolicy.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/autoscale/CreatePolicy.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -82,7 +82,7 @@ public class CreatePolicy implements Closeable {
             .buildApi(AutoscaleApi.class);
 
       groupApi = autoscaleApi.getGroupApiForZone(ZONE);
-   }   
+   }
 
    private void createPolicy() {
       System.out.format("Create Autoscale Group%n");

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/autoscale/CreateWebhook.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/autoscale/CreateWebhook.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/autoscale/ExecuteWebhook.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/autoscale/ExecuteWebhook.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -37,7 +37,7 @@ import com.google.common.io.Closeables;
 import com.google.common.util.concurrent.Uninterruptibles;
 
 /**
- * This example executes a scaling policy in two ways: 
+ * This example executes a scaling policy in two ways:
  * - Authenticated API call using jclouds.
  * - Anonymously using just the webhook URL.
  */

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/autoscale/UpdatePolicy.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/autoscale/UpdatePolicy.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/autoscale/Utils.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/autoscale/Utils.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/Constants.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/Constants.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/CreateSnapshot.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/CreateSnapshot.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/CreateVolumeAndAttach.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/CreateVolumeAndAttach.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -75,7 +75,7 @@ public class CreateVolumeAndAttach implements Closeable {
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/DeleteSnapshot.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/DeleteSnapshot.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -41,8 +41,8 @@ public class DeleteSnapshot implements Closeable {
    /**
     * To get a username and API key see
     * http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
-    * The first argument (args[0]) must be your username 
+    *
+    * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
    public static void main(String[] args) throws IOException {
@@ -51,10 +51,10 @@ public class DeleteSnapshot implements Closeable {
       try {
          Snapshot snapshot = deleteSnapshot.getSnapshot();
          deleteSnapshot.deleteSnapshot(snapshot);
-      } 
+      }
       catch (Exception e) {
          e.printStackTrace();
-      } 
+      }
       finally {
          deleteSnapshot.close();
       }
@@ -82,7 +82,7 @@ public class DeleteSnapshot implements Closeable {
 
    private void deleteSnapshot(Snapshot snapshot) throws TimeoutException {
       System.out.format("Delete Snapshot%n");
-      
+
       boolean result = snapshotApi.delete(snapshot.getId());
 
       // Wait for the snapshot to be deleted before moving on

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/DeleteVolume.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/DeleteVolume.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -41,7 +41,7 @@ public class DeleteVolume implements Closeable {
    /**
     * To get a username and API key see
     * http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/DetachVolume.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/DetachVolume.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -70,7 +70,7 @@ public class DetachVolume implements Closeable {
    /**
     * To get a username and API key see
     * http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/ListSnapshots.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/ListSnapshots.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -39,7 +39,7 @@ public class ListSnapshots implements Closeable {
    /**
     * To get a username and API key see
     * http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/ListVolumeAttachments.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/ListVolumeAttachments.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -45,7 +45,7 @@ public class ListVolumeAttachments implements Closeable {
    /**
     * To get a username and API key see
     * http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/ListVolumeTypes.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/ListVolumeTypes.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -39,7 +39,7 @@ public class ListVolumeTypes implements Closeable {
    /**
     * To get a username and API key see
     * http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/ListVolumes.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudblockstorage/ListVolumes.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -39,7 +39,7 @@ public class ListVolumes implements Closeable {
    /**
     * To get a username and API key see
     * http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddatabases/Constants.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddatabases/Constants.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddatabases/CreateDatabase.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddatabases/CreateDatabase.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddatabases/CreateInstance.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddatabases/CreateInstance.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -35,7 +35,7 @@ import com.google.common.io.Closeables;
 import static org.jclouds.examples.rackspace.clouddatabases.Constants.*;
 
 /**
- * This example creates a Cloud Databases instance. 
+ * This example creates a Cloud Databases instance.
  * This instance will be used to run a database later on in the Create Database example.
  */
 public class CreateInstance implements Closeable {
@@ -43,9 +43,9 @@ public class CreateInstance implements Closeable {
    private final FlavorApi flavorApi;
 
    /**
-    * To get a username and API key see 
+    * To get a username and API key see
     * http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument  (args[0]) must be your username.
     * The second argument (args[1]) must be your API key.
     */

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddatabases/CreateUser.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddatabases/CreateUser.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -41,21 +41,21 @@ public class CreateUser implements Closeable {
    private final UserApi userApi;
 
    /**
-    * To get a username and API key see 
+    * To get a username and API key see
     * http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument  (args[0]) must be your username.
     * The second argument (args[1]) must be your API key.
     */
-   public static void main(String[] args) throws IOException {      
+   public static void main(String[] args) throws IOException {
       CreateUser createUser = new CreateUser(args[0], args[1]);
 
       try {
          createUser.createUser();
-      } 
+      }
       catch (Exception e) {
          e.printStackTrace();
-      } 
+      }
       finally {
          createUser.close();
       }
@@ -87,7 +87,7 @@ public class CreateUser implements Closeable {
       System.out.format("Create User%n");
 
       boolean result = userApi.create(NAME, PASSWORD, NAME);
-      
+
       System.out.format("  %s%n", result);
    }
 

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddatabases/DeleteDatabase.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddatabases/DeleteDatabase.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -41,9 +41,9 @@ public class DeleteDatabase implements Closeable {
    private final DatabaseApi databaseApi;
 
    /**
-    * To get a username and API key see 
+    * To get a username and API key see
     * http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument  (args[0]) must be your username.
     * The second argument (args[1]) must be your API key.
     */
@@ -52,10 +52,10 @@ public class DeleteDatabase implements Closeable {
 
       try {
          deleteDatabase.deleteDatabase();
-      } 
+      }
       catch (Exception e) {
          e.printStackTrace();
-      } 
+      }
       finally {
          deleteDatabase.close();
       }

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddatabases/DeleteInstance.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddatabases/DeleteInstance.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -40,21 +40,21 @@ public class DeleteInstance implements Closeable {
    private final InstanceApi instanceApi;
 
    /**
-    * To get a username and API key see 
+    * To get a username and API key see
     * http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument  (args[0]) must be your username.
     * The second argument (args[1]) must be your API key.
     */
-   public static void main(String[] args) throws IOException {      
+   public static void main(String[] args) throws IOException {
       DeleteInstance deleteInstance = new DeleteInstance(args[0], args[1]);
 
       try {
          deleteInstance.deleteInstance(deleteInstance.getInstance());
-      } 
+      }
       catch (Exception e) {
          e.printStackTrace();
-      } 
+      }
       finally {
          deleteInstance.close();
       }

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddatabases/DeleteUser.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddatabases/DeleteUser.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -41,21 +41,21 @@ public class DeleteUser implements Closeable {
    private final UserApi userApi;
 
    /**
-    * To get a username and API key see 
+    * To get a username and API key see
     * http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument  (args[0]) must be your username.
     * The second argument (args[1]) must be your API key.
     */
-   public static void main(String[] args) throws IOException {      
+   public static void main(String[] args) throws IOException {
       DeleteUser deleteUser = new DeleteUser(args[0], args[1]);
 
       try {
          deleteUser.deleteUser();
-      } 
+      }
       catch (Exception e) {
          e.printStackTrace();
-      } 
+      }
       finally {
          deleteUser.close();
       }

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddatabases/GrantRootAccess.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddatabases/GrantRootAccess.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -39,21 +39,21 @@ public class GrantRootAccess implements Closeable {
    private final InstanceApi instanceApi;
 
    /**
-    * To get a username and API key see 
+    * To get a username and API key see
     * http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument  (args[0]) must be your username.
     * The second argument (args[1]) must be your API key.
     */
-   public static void main(String[] args) throws IOException {      
+   public static void main(String[] args) throws IOException {
       GrantRootAccess grantRootAccess = new GrantRootAccess(args[0], args[1]);
 
       try {
          grantRootAccess.grantRootAccess();
-      } 
+      }
       catch (Exception e) {
          e.printStackTrace();
-      } 
+      }
       finally {
          grantRootAccess.close();
       }
@@ -82,9 +82,9 @@ public class GrantRootAccess implements Closeable {
 
    private void grantRootAccess() throws TimeoutException {
       System.out.format("Grant root access%n");
-      
+
       String password = instanceApi.enableRoot(getInstance().getId()); // enable root on the instance
-      
+
       System.out.format("  Password: %s%n", password); // remove this in your code, never echo credentials
    }
 

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddatabases/TestDatabase.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddatabases/TestDatabase.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -53,41 +53,41 @@ import static org.jclouds.examples.rackspace.clouddatabases.Constants.*;
  * This example uses the already created database instance, database user, and database from the examples:
  * CreateInstance, CreateDatabase, CreateUser
  * This example will create a load balancer to allow public access to the database.
- * The load balancer is only needed for public access - it is not needed when accessing the database from the rackspace network. 
+ * The load balancer is only needed for public access - it is not needed when accessing the database from the rackspace network.
  * For more information: http://www.rackspace.com/knowledge_center/article/public-vs-private-access
  * The example connects to the database using JDBC over the load balancer and executes a simple command to confirm that the database is online.
  */
 public class TestDatabase implements Closeable {
    // If you want to log instead of print, uncomment the line below
-   // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TestDatabase.class); 
+   // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TestDatabase.class);
    private final CloudLoadBalancersApi clbApi;
    private final LoadBalancerApi lbApi;
    private final TroveApi troveApi;
    private final InstanceApi instanceApi;
 
    /**
-    * To get a username and API key see 
+    * To get a username and API key see
     * http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument  (args[0]) must be your username.
     * The second argument (args[1]) must be your API key.
-    */   
-   public static void main(String[] args) throws IOException {      
+    */
+   public static void main(String[] args) throws IOException {
       TestDatabase testDatabase = new TestDatabase(args[0], args[1]);
 
       try {
          Set<AddNode> addNodes = testDatabase.addNodesOfDatabaseInstances();
          testDatabase.createLoadBalancer(addNodes);
-         
+
          boolean success;
          do{
             success = testDatabase.testDatabase();
             Uninterruptibles.sleepUninterruptibly(5, TimeUnit.SECONDS);
          } while(!success);
-      } 
+      }
       catch (Exception e) {
          e.printStackTrace();
-      } 
+      }
       finally {
          testDatabase.close();
       }
@@ -121,7 +121,7 @@ public class TestDatabase implements Closeable {
 
       throw new RuntimeException(NAME + " not found. Run the CreateInstance example first.");
    }
-   
+
    /**
     * @return Returns a set of a single cloud load balancer node that can be used to connect to the database from the public Internet
     */
@@ -131,13 +131,13 @@ public class TestDatabase implements Closeable {
                                  .condition(Node.Condition.ENABLED)
                                  .port(3306)
                                  .build();
-      
-      return Sets.newHashSet(addNode01);      
+
+      return Sets.newHashSet(addNode01);
    }
-   
+
    /**
     * Builds and executes the request to create a load balancer service using a set of nodes.
-    * 
+    *
     * @param addNodes The set of cloud load balancer nodes.
     */
    private void createLoadBalancer(Set<AddNode> addNodes) throws TimeoutException {
@@ -158,32 +158,32 @@ public class TestDatabase implements Closeable {
       do {
          loadBalancer = lbApi.create(createLB);
          Uninterruptibles.sleepUninterruptibly(30, TimeUnit.SECONDS);
-      } 
+      }
       while(loadBalancer == null);
 
-      
+
       // Wait for the Load Balancer to become Active before moving on.
       // If you want to know what's happening during the polling, enable logging. See
       // /jclouds-example/rackspace/src/main/java/org/jclouds/examples/rackspace/Logging.java
       // Even when the load balancer returns active, it might take a while before connections to the database are possible.
       if (!LoadBalancerPredicates.awaitAvailable(lbApi).apply(loadBalancer)) {
-         throw new TimeoutException("Timeout on loadBalancer: " + loadBalancer);     
+         throw new TimeoutException("Timeout on loadBalancer: " + loadBalancer);
       }
-      
+
       System.out.format("  %s%n", loadBalancer);
    }
-   
+
    private String getVirtualIPv4(Set<VirtualIPWithId> set) {
       for (VirtualIPWithId virtualIP: set) {
-         if (virtualIP.getType().equals(VirtualIP.Type.PUBLIC) && 
+         if (virtualIP.getType().equals(VirtualIP.Type.PUBLIC) &&
              virtualIP.getIpVersion().equals(VirtualIP.IPVersion.IPV4)) {
             return virtualIP.getAddress();
          }
       }
-      
+
       throw new RuntimeException("Public IPv4 address not found.");
    }
-   
+
    /**
     * @return LoadBalancer The LoadBalancer created in this example.
     */
@@ -200,15 +200,15 @@ public class TestDatabase implements Closeable {
    /**
     * Connects to the database using JDBC over the load balancer and executes a simple query without creating a database table.
     * This will verify that the database engine is running on the remote instance.
-    * 
+    *
     * @return true if connection successful and database engine responsive.
     */
    private boolean testDatabase() throws TimeoutException {
       System.out.format("Connect to database%n");
-      
+
       // See http://dev.mysql.com/doc/refman/5.6/en/connector-j-examples.html
       Connection conn;
-      
+
       try {
          StringBuilder connString = new StringBuilder();
          connString.append("jdbc:mysql://"); // Begin building the JDBC connection string by specifying the database type.
@@ -219,9 +219,9 @@ public class TestDatabase implements Closeable {
          connString.append(NAME); // User name
          connString.append("&password=");
          connString.append(PASSWORD); // Database user password
-         
+
          System.out.format("  Connecting to %s%n", connString); // remove this in your code, never echo credentials
-         
+
          conn = DriverManager.getConnection(connString.toString());
 
          Statement stmt = null;
@@ -233,18 +233,18 @@ public class TestDatabase implements Closeable {
             rs.first();
 
             System.out.format("  3+5 is %s%n", rs.getInt(1));
-         } 
+         }
          catch (SQLException e){
             System.out.format("SQLException: %s%n", e.getMessage());
             System.out.format("SQLState: %s%n", e.getSQLState());
             System.out.format("VendorError: %s%n", e.getErrorCode());
             e.printStackTrace();
-            
+
             return false;
-         } 
-         finally {            
+         }
+         finally {
             // Release resources in reverse order of creation.
-            
+
             if (rs != null) {
                try {
                   rs.close();
@@ -262,7 +262,7 @@ public class TestDatabase implements Closeable {
                   // Ignore - you might get an exception if closing out of order.
                }
             }
-             
+
             if(conn != null) {
                try {
                   conn.close();
@@ -272,13 +272,13 @@ public class TestDatabase implements Closeable {
                }
             }
          }
-      } 
+      }
       catch (SQLException e) {
          System.out.format("SQLException: %s%n", e.getMessage());
          System.out.format("SQLState: %s%n", e.getSQLState());
          System.out.format("VendorError: %s%n", e.getErrorCode());
          e.printStackTrace();
-         
+
          return false;
       }
 

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddns/CRUDReverseDNSRecords.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddns/CRUDReverseDNSRecords.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -41,8 +41,8 @@ import static org.jclouds.examples.rackspace.clouddns.Constants.*;
 import static org.jclouds.rackspace.clouddns.v1.predicates.JobPredicates.awaitComplete;
 
 /**
- * This example creates reverse DNS records on an existing domain for a Cloud Server. 
- *  
+ * This example creates reverse DNS records on an existing domain for a Cloud Server.
+ *
  */
 public class CRUDReverseDNSRecords implements Closeable {
    private final CloudDNSApi dnsApi;
@@ -50,7 +50,7 @@ public class CRUDReverseDNSRecords implements Closeable {
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -84,7 +84,7 @@ public class CRUDReverseDNSRecords implements Closeable {
 
    private RecordDetail createReverseDNSRecords(NodeMetadata node) throws TimeoutException {
       System.out.format("Create Reverse DNS Records%n");
-      
+
       Record createPTRRecordIPv4 = Record.builder()
             .name(NAME)
             .type("PTR")
@@ -95,7 +95,7 @@ public class CRUDReverseDNSRecords implements Closeable {
       Set<Record> records = ImmutableSet.of(createPTRRecordIPv4);
 
       Iterable<RecordDetail> recordDetails = awaitComplete(dnsApi, reverseDNSApi.create(node.getUri(), records));
-      
+
       RecordDetail recordDetail = recordDetails.iterator().next();
       System.out.format("  %s%n", recordDetail);
 
@@ -106,7 +106,7 @@ public class CRUDReverseDNSRecords implements Closeable {
       System.out.format("List Reverse DNS Records%n");
 
       Iterable<RecordDetail> recordDetails = reverseDNSApi.list(node.getUri()).concat();
-      
+
       for (RecordDetail recordDetail: recordDetails) {
          System.out.format("  %s%n", recordDetail);
       }
@@ -119,7 +119,7 @@ public class CRUDReverseDNSRecords implements Closeable {
       Map<String, Record> idsToRecords = ImmutableMap.of(recordDetail.getId(), updatePTRRecord);
 
       awaitComplete(dnsApi, reverseDNSApi.update(node.getUri(), idsToRecords));
-      
+
       System.out.format("  %s%n", reverseDNSApi.get(node.getUri(), recordDetail.getId()));
    }
 
@@ -127,14 +127,14 @@ public class CRUDReverseDNSRecords implements Closeable {
       System.out.format("Delete Reverse DNS Records%n");
 
       awaitComplete(dnsApi, dnsApi.getReverseDNSApiForService(CLOUD_SERVERS).deleteAll(node.getUri()));
-      
+
       System.out.format("  Deleted all reverse DNS records%n");
    }
 
    /**
     * Always close your service when you're done with it.
-    * 
-    * Note that closing quietly like this is not necessary in Java 7. 
+    *
+    * Note that closing quietly like this is not necessary in Java 7.
     * You would use try-with-resources in the main method instead.
     */
    public void close() throws IOException {

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddns/Constants.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddns/Constants.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddns/CreateDomains.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddns/CreateDomains.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -38,15 +38,15 @@ import static org.jclouds.examples.rackspace.clouddns.Constants.*;
 import static org.jclouds.rackspace.clouddns.v1.predicates.JobPredicates.awaitComplete;
 
 /**
- * This example creates a domain with subdomains and records. 
- *  
+ * This example creates a domain with subdomains and records.
+ *
  */
 public class CreateDomains implements Closeable {
    private final CloudDNSApi dnsApi;
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -72,34 +72,34 @@ public class CreateDomains implements Closeable {
 
    private void createDomains() throws TimeoutException {
       System.out.format("Create Domains%n");
-      
+
       Record createMXRecord = Record.builder()
             .name(NAME)
             .type("MX")
             .data("mail." + NAME)
             .priority(11235)
             .build();
-      
+
       Record createARecord = Record.builder()
             .name(NAME)
             .type("A")
             .data("10.0.0.1")
             .build();
-      
+
       Set<Record> createRecords = ImmutableSet.of(createMXRecord, createARecord);
-      
+
       CreateSubdomain createSubdomain1 = CreateSubdomain.builder()
             .name("dev." + NAME)
             .email("jclouds@" + NAME)
             .comment("Hello dev subdomain")
             .build();
-      
+
       CreateSubdomain createSubdomain2 = CreateSubdomain.builder()
             .name("test." + NAME)
             .email("jclouds@" + NAME)
             .comment("Hello test subdomain")
             .build();
-      
+
       Set<CreateSubdomain> createSubdomains = ImmutableSet.of(createSubdomain1, createSubdomain2);
 
       CreateDomain createDomain1 = CreateDomain.builder()
@@ -120,15 +120,15 @@ public class CreateDomains implements Closeable {
 
       Set<CreateDomain> createDomains = ImmutableSet.of(createDomain1, createDomain2);
       Map<String, Domain> domains = DomainFunctions.toDomainMap(awaitComplete(dnsApi, dnsApi.getDomainApi().create(createDomains)));
-      
+
       System.out.format("  %s%n", domains.get(NAME));
       System.out.format("  %s%n", domains.get(ALT_NAME));
    }
 
    /**
     * Always close your service when you're done with it.
-    * 
-    * Note that closing quietly like this is not necessary in Java 7. 
+    *
+    * Note that closing quietly like this is not necessary in Java 7.
     * You would use try-with-resources in the main method instead.
     */
    public void close() throws IOException {

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddns/CreateRecords.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddns/CreateRecords.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -36,15 +36,15 @@ import static org.jclouds.examples.rackspace.clouddns.Constants.PROVIDER;
 import static org.jclouds.rackspace.clouddns.v1.predicates.JobPredicates.awaitComplete;
 
 /**
- * This example creates records on an existing domain. 
- *  
+ * This example creates records on an existing domain.
+ *
  */
 public class CreateRecords implements Closeable {
    private final CloudDNSApi dnsApi;
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -70,11 +70,11 @@ public class CreateRecords implements Closeable {
 
    private void createRecords() throws TimeoutException {
       System.out.format("Create Records%n");
-      
+
       int domainId = 0;
 
       Iterable<Domain> domains = dnsApi.getDomainApi().list().concat();
-      
+
       for (Domain domain: domains) {
          if (domain.getName().equals(ALT_NAME)) {
             domainId = domain.getId();
@@ -86,15 +86,15 @@ public class CreateRecords implements Closeable {
             .type("TXT")
             .data("This is a TXT record")
             .build();
-      
+
       Record createARecord = Record.builder()
             .name(ALT_NAME)
             .type("A")
             .data("10.0.0.2")
             .build();
-      
+
       Set<Record> createRecords = ImmutableSet.of(createTXTRecord, createARecord);
-      
+
       Set<RecordDetail> recordDetails = awaitComplete(dnsApi, dnsApi.getRecordApiForDomain(domainId).create(createRecords));
 
       for (RecordDetail recordDetail: recordDetails) {
@@ -104,8 +104,8 @@ public class CreateRecords implements Closeable {
 
    /**
     * Always close your service when you're done with it.
-    * 
-    * Note that closing quietly like this is not necessary in Java 7. 
+    *
+    * Note that closing quietly like this is not necessary in Java 7.
     * You would use try-with-resources in the main method instead.
     */
    public void close() throws IOException {

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddns/DeleteDomains.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddns/DeleteDomains.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -33,15 +33,15 @@ import static org.jclouds.examples.rackspace.clouddns.Constants.*;
 import static org.jclouds.rackspace.clouddns.v1.predicates.JobPredicates.awaitComplete;
 
 /**
- * This example deletes all domains. 
- *  
+ * This example deletes all domains.
+ *
  */
 public class DeleteDomains implements Closeable {
    private final CloudDNSApi dnsApi;
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -67,20 +67,20 @@ public class DeleteDomains implements Closeable {
 
    private void deleteAllDomains() throws TimeoutException {
       System.out.format("Delete Domains%n");
-      
+
       Set<Domain> allDomains = dnsApi.getDomainApi().list().concat().toSet();
       Iterable<Domain> topLevelDomains = Iterables.filter(allDomains, IS_DOMAIN);
       Iterable<Integer> topLevelDomainIds = Iterables.transform(topLevelDomains, GET_DOMAIN_ID);
-      
+
       awaitComplete(dnsApi, dnsApi.getDomainApi().delete(topLevelDomainIds, true));
-            
+
       System.out.format("  Deleted %s top level domains and all subdomains%n", Iterables.size(topLevelDomainIds));
    }
 
    /**
     * Always close your service when you're done with it.
-    * 
-    * Note that closing quietly like this is not necessary in Java 7. 
+    *
+    * Note that closing quietly like this is not necessary in Java 7.
     * You would use try-with-resources in the main method instead.
     */
    public void close() throws IOException {

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddns/DeleteRecords.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddns/DeleteRecords.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -36,15 +36,15 @@ import static org.jclouds.rackspace.clouddns.v1.functions.RecordFunctions.GET_RE
 import static org.jclouds.rackspace.clouddns.v1.predicates.JobPredicates.awaitComplete;
 
 /**
- * This example deletes the records on a domain. 
- *  
+ * This example deletes the records on a domain.
+ *
  */
 public class DeleteRecords implements Closeable {
    private final CloudDNSApi dnsApi;
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -75,25 +75,25 @@ public class DeleteRecords implements Closeable {
             return domain;
          }
       }
-      
+
       throw new RuntimeException(ALT_NAME + " not found. Run CreateDomains example first.");
    }
 
    private void deleteRecords(Domain domain) throws TimeoutException {
       System.out.format("Delete Records%n");
-      
+
       Set<RecordDetail> recordDetails = dnsApi.getRecordApiForDomain(domain.getId()).listByType("TXT").concat().toSet();
       Iterable<String> recordIds = Iterables.transform(recordDetails, GET_RECORD_ID);
-      
+
       awaitComplete(dnsApi, dnsApi.getRecordApiForDomain(domain.getId()).delete(recordIds));
-      
+
       System.out.format("  Deleted %s records", Iterables.size(recordDetails));
    }
-   
+
    /**
     * Always close your service when you're done with it.
-    * 
-    * Note that closing quietly like this is not necessary in Java 7. 
+    *
+    * Note that closing quietly like this is not necessary in Java 7.
     * You would use try-with-resources in the main method instead.
     */
    public void close() throws IOException {

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddns/ListDomains.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddns/ListDomains.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -30,15 +30,15 @@ import java.io.IOException;
 import static org.jclouds.examples.rackspace.clouddns.Constants.*;
 
 /**
- * This example lists domains. 
- *  
+ * This example lists domains.
+ *
  */
 public class ListDomains implements Closeable {
    private final CloudDNSApi dnsApi;
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -69,10 +69,10 @@ public class ListDomains implements Closeable {
 
       Iterable<Domain> domains = dnsApi.getDomainApi().list().concat();
       int domainId = 0;
-      
+
       for (Domain domain: domains) {
          System.out.format("  %s%n", domain);
-         
+
          if (domain.getName().equals(NAME)) {
             domainId = domain.getId();
          }
@@ -83,9 +83,9 @@ public class ListDomains implements Closeable {
 
    private void listWithFilterByNamesMatching() {
       System.out.format("List With Filter By Names Matching%n");
-      
+
       Iterable<Domain> domains = dnsApi.getDomainApi().listWithFilterByNamesMatching(ALT_NAME).concat();
-      
+
       for (Domain domain: domains) {
          System.out.format("  %s%n", domain);
       }
@@ -95,7 +95,7 @@ public class ListDomains implements Closeable {
       System.out.format("List Subdomains%n");
 
       Iterable<Subdomain> subdomains = dnsApi.getDomainApi().listSubdomains(domainId).concat();
-      
+
       for (Subdomain subdomain: subdomains) {
          System.out.format("  %s%n", subdomain);
       }
@@ -103,8 +103,8 @@ public class ListDomains implements Closeable {
 
    /**
     * Always close your service when you're done with it.
-    * 
-    * Note that closing quietly like this is not necessary in Java 7. 
+    *
+    * Note that closing quietly like this is not necessary in Java 7.
     * You would use try-with-resources in the main method instead.
     */
    public void close() throws IOException {

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddns/ListRecords.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddns/ListRecords.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -31,15 +31,15 @@ import static org.jclouds.examples.rackspace.clouddns.Constants.NAME;
 import static org.jclouds.examples.rackspace.clouddns.Constants.PROVIDER;
 
 /**
- * This example lists records. 
- *  
+ * This example lists records.
+ *
  */
 public class ListRecords implements Closeable {
    private final CloudDNSApi dnsApi;
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -72,7 +72,7 @@ public class ListRecords implements Closeable {
             return domain;
          }
       }
-      
+
       throw new RuntimeException(NAME + " not found. Run CreateDomains example first.");
    }
 
@@ -80,7 +80,7 @@ public class ListRecords implements Closeable {
       System.out.format("List Records%n");
 
       Iterable<RecordDetail> recordDetails = dnsApi.getRecordApiForDomain(domain.getId()).list().concat();
-      
+
       for (RecordDetail recordDetail: recordDetails) {
          System.out.format("  %s%n", recordDetail);
       }
@@ -90,7 +90,7 @@ public class ListRecords implements Closeable {
       System.out.format("List Records by Name and Type%n");
 
       Iterable<RecordDetail> recordDetails = dnsApi.getRecordApiForDomain(domain.getId()).listByNameAndType(NAME, "A").concat();
-      
+
       for (RecordDetail recordDetail: recordDetails) {
          System.out.format("  %s%n", recordDetail);
       }
@@ -100,7 +100,7 @@ public class ListRecords implements Closeable {
       System.out.format("List Records by Type%n");
 
       Iterable<RecordDetail> recordDetails = dnsApi.getRecordApiForDomain(domain.getId()).listByType("MX").concat();
-      
+
       for (RecordDetail recordDetail: recordDetails) {
          System.out.format("  %s%n", recordDetail);
       }
@@ -108,8 +108,8 @@ public class ListRecords implements Closeable {
 
    /**
     * Always close your service when you're done with it.
-    * 
-    * Note that closing quietly like this is not necessary in Java 7. 
+    *
+    * Note that closing quietly like this is not necessary in Java 7.
     * You would use try-with-resources in the main method instead.
     */
    public void close() throws IOException {

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddns/UpdateDomains.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddns/UpdateDomains.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -33,15 +33,15 @@ import static org.jclouds.examples.rackspace.clouddns.Constants.*;
 import static org.jclouds.rackspace.clouddns.v1.predicates.JobPredicates.awaitComplete;
 
 /**
- * This example updates a domain. 
- *  
+ * This example updates a domain.
+ *
  */
 public class UpdateDomains implements Closeable {
    private final CloudDNSApi dnsApi;
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -68,17 +68,17 @@ public class UpdateDomains implements Closeable {
 
    private void updateDomain() throws TimeoutException {
       System.out.format("Update Domain%n");
-      
+
       int domainId = 0;
 
       Iterable<Domain> domains = dnsApi.getDomainApi().list().concat();
-      
+
       for (Domain domain: domains) {
          if (domain.getName().equals(ALT_NAME)) {
             domainId = domain.getId();
          }
       }
-      
+
       UpdateDomain updateDomain = UpdateDomain.builder()
             .email("jcloudie@" + ALT_NAME)
             .ttl(600001)
@@ -86,29 +86,29 @@ public class UpdateDomains implements Closeable {
             .build();
 
       awaitComplete(dnsApi, dnsApi.getDomainApi().update(domainId, updateDomain));
-      
+
       System.out.format("  %s%n", dnsApi.getDomainApi().get(domainId));
    }
 
    private void updateDomains() throws TimeoutException {
       System.out.format("Update Domains%n");
-      
+
       Iterable<Domain> domains = dnsApi.getDomainApi().list().concat();
       Iterable<Integer> domainIds = Iterables.transform(domains, GET_DOMAIN_ID);
-      
+
       awaitComplete(dnsApi, dnsApi.getDomainApi().updateEmail(domainIds, "jclouder@" + NAME));
-      
+
       domains = dnsApi.getDomainApi().list().concat();
-      
+
       for (Domain domain: domains) {
          System.out.format("  %s%n", domain);
       }
    }
-   
+
    /**
     * Always close your service when you're done with it.
-    * 
-    * Note that closing quietly like this is not necessary in Java 7. 
+    *
+    * Note that closing quietly like this is not necessary in Java 7.
     * You would use try-with-resources in the main method instead.
     */
    public void close() throws IOException {

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddns/UpdateRecords.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/clouddns/UpdateRecords.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -39,15 +39,15 @@ import static org.jclouds.examples.rackspace.clouddns.Constants.PROVIDER;
 import static org.jclouds.rackspace.clouddns.v1.predicates.JobPredicates.awaitComplete;
 
 /**
- * This example updates the records on a domain. 
- *  
+ * This example updates the records on a domain.
+ *
  */
 public class UpdateRecords implements Closeable {
    private final CloudDNSApi dnsApi;
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -79,32 +79,32 @@ public class UpdateRecords implements Closeable {
             return domain;
          }
       }
-      
+
       throw new RuntimeException(NAME + " not found. Run CreateDomains example first.");
    }
 
    private void updateRecord(Domain domain) throws TimeoutException {
       System.out.format("Update Record%n");
-      
+
       RecordDetail recordDetail = dnsApi.getRecordApiForDomain(domain.getId()).getByNameAndTypeAndData(NAME, "A", "10.0.0.1");
       Record updateRecord = recordDetail.getRecord().toBuilder().data("10.0.1.0").build();
-      
+
       awaitComplete(dnsApi, dnsApi.getRecordApiForDomain(domain.getId()).update(recordDetail.getId(), updateRecord));
-      
+
       System.out.format("  %s%n", dnsApi.getRecordApiForDomain(domain.getId()).get(recordDetail.getId()));
    }
 
    private void updateRecords(Domain domain) throws TimeoutException {
       System.out.format("Update Records%n");
-      
+
       Set<RecordDetail> recordDetails = dnsApi.getRecordApiForDomain(domain.getId()).listByType("A").concat().toSet();
       Map<String, Record> idsToRecords = RecordFunctions.toRecordMap(recordDetails);
-      Map<String, Record> updateRecords = Maps.transformValues(idsToRecords, updateTTLAndComment(235813, "New TTL")); 
-      
+      Map<String, Record> updateRecords = Maps.transformValues(idsToRecords, updateTTLAndComment(235813, "New TTL"));
+
       awaitComplete(dnsApi, dnsApi.getRecordApiForDomain(domain.getId()).update(updateRecords));
-      
+
       Iterable<RecordDetail> recordDetailsUpdated = dnsApi.getRecordApiForDomain(domain.getId()).listByType("A").concat();
-      
+
       for (RecordDetail recordDetailUpdated: recordDetailsUpdated) {
          System.out.format("  %s%n", recordDetailUpdated);
       }
@@ -117,11 +117,11 @@ public class UpdateRecords implements Closeable {
          }
       };
    }
-   
+
    /**
     * Always close your service when you're done with it.
-    * 
-    * Note that closing quietly like this is not necessary in Java 7. 
+    *
+    * Note that closing quietly like this is not necessary in Java 7.
     * You would use try-with-resources in the main method instead.
     */
    public void close() throws IOException {

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/CloudFilesPublish.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/CloudFilesPublish.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -55,7 +55,7 @@ public class CloudFilesPublish implements Closeable {
 
    /**
     * To get a username and API key see http://jclouds.apache.org/guides/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -91,7 +91,7 @@ public class CloudFilesPublish implements Closeable {
       Multimap<String, String> enableStaticWebHeaders =
             ImmutableMultimap.of(STATIC_WEB_INDEX, FILENAME + SUFFIX,
                                  STATIC_WEB_ERROR, "error.html");
-      
+
       CreateContainerOptions opts = new CreateContainerOptions().headers(enableStaticWebHeaders);
       cloudFiles.getContainerApiForRegion(REGION).create(CONTAINER_PUBLISH, opts);
 

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/Constants.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/Constants.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/CreateContainer.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/CreateContainer.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -34,14 +34,14 @@ import com.google.common.io.Closeables;
 
 /**
  * Create a Cloud Files container with some metadata associated with it.
- *  
+ *
  */
 public class CreateContainer implements Closeable {
    private final CloudFilesApi cloudFiles;
 
    /**
     * To get a username and API key see http://jclouds.apache.org/guides/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/CrossOriginResourceSharingContainer.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/CrossOriginResourceSharingContainer.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -39,10 +39,10 @@ import com.google.common.io.Closeables;
 
 /**
  * Create a Cloud Files container with Cross Origin Resource Sharing (CORS) allowed. CORS container headers allow
- * users to upload files from one website--or origin--to your Cloud Files account. When you set the CORS headers on 
- * your container, you tell Cloud Files which sites may post to your account, how often your container checks its 
+ * users to upload files from one website--or origin--to your Cloud Files account. When you set the CORS headers on
+ * your container, you tell Cloud Files which sites may post to your account, how often your container checks its
  * allowed sites list, and whether or not metadata headers can be passed with the objects.
- *  
+ *
  */
 public class CrossOriginResourceSharingContainer implements Closeable {
    private final CloudFilesApi cloudFiles;
@@ -50,7 +50,7 @@ public class CrossOriginResourceSharingContainer implements Closeable {
 
    /**
     * To get a username and API key see http://jclouds.apache.org/guides/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -78,8 +78,8 @@ public class CrossOriginResourceSharingContainer implements Closeable {
 
    /**
     * Create a Cross Origin Resource Sharing container.
-    * 
-    * Access-Control-Allow-Origin:  Which URLs can make Cross Origin Requests. Format is http://www.example.com. 
+    *
+    * Access-Control-Allow-Origin:  Which URLs can make Cross Origin Requests. Format is http://www.example.com.
     *                               Separate URLs with a space. An asterisk (*) allows all.
     * Access-Control-Max-Age:       The maximum age for the browser to cache the options request, in seconds.
     * Access-Control-Allow-Headers: Which custom metadata headers you allow to be assigned to objects in this container.
@@ -116,7 +116,7 @@ public class CrossOriginResourceSharingContainer implements Closeable {
 
       Container container = containerApi.get(CONTAINER);
       System.out.format("    %s%n", container.getMetadata());
-   }   
+   }
 
    /**
     * Always close your service when you're done with it.

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/DeleteObjectsAndContainer.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/DeleteObjectsAndContainer.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -39,14 +39,14 @@ import com.google.common.io.Closeables;
 /**
  * Delete the objects from the CreateObjects example and delete the Cloud Files container from the
  * CreateContainer example.
- *  
+ *
  */
 public class DeleteObjectsAndContainer implements Closeable {
    private final CloudFilesApi cloudFiles;
 
    /**
     * To get a username and API key see http://jclouds.apache.org/guides/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/GenerateTempURL.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/GenerateTempURL.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -41,31 +41,31 @@ import static org.jclouds.examples.rackspace.cloudfiles.Constants.PROVIDER;
 import static org.jclouds.examples.rackspace.cloudfiles.Constants.REGION;
 
 /**
- * The Temporary URL feature (TempURL) allows you to create limited-time Internet addresses which allow you to grant 
- * limited access to your Cloud Files account. Using TempURL, you may allow others to retrieve or place objects in 
- * your Cloud Files account for as long or as short a time as you wish. Access to the TempURL is independent of 
- * whether or not your account is CDN-enabled. And even if you don't CDN-enable a directory, you can still grant 
+ * The Temporary URL feature (TempURL) allows you to create limited-time Internet addresses which allow you to grant
+ * limited access to your Cloud Files account. Using TempURL, you may allow others to retrieve or place objects in
+ * your Cloud Files account for as long or as short a time as you wish. Access to the TempURL is independent of
+ * whether or not your account is CDN-enabled. And even if you don't CDN-enable a directory, you can still grant
  * temporary public access through a TempURL.
- * 
+ *
  * This feature is useful if you want to allow a limited audience to download a file from your Cloud Files account or
- * website. You can give out the TempURL and know that after a specified time, no one will be able to access your 
- * object through the address. Or, if you want to allow your audience to upload objects into your Cloud Files account, 
+ * website. You can give out the TempURL and know that after a specified time, no one will be able to access your
+ * object through the address. Or, if you want to allow your audience to upload objects into your Cloud Files account,
  * you can give them a TempURL. After the specified time expires, no one will be able to upload to the address.
- * 
- * Additionally, you need not worry about time running out when someone downloads a large object. If the time expires 
+ *
+ * Additionally, you need not worry about time running out when someone downloads a large object. If the time expires
  * while a file is being retrieved, the download will continue until it is finished. Only the link will expire.
- *  
+ *
  */
 public class GenerateTempURL implements Closeable {
    private static final String FILENAME = "object.txt";
    private static final int TEN_MINUTES = 10 * 60;
-   
+
    private final BlobStore blobStore;
    private final RegionScopedBlobStoreContext blobStoreContext;
 
    /**
     * To get a username and API key see http://jclouds.apache.org/guides/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -91,25 +91,25 @@ public class GenerateTempURL implements Closeable {
             .buildView(RegionScopedBlobStoreContext.class);
       blobStore = blobStoreContext.blobStoreInRegion(REGION);
    }
-   
+
    private void generatePutTempURL() throws IOException {
       System.out.format("Generate PUT Temp URL%n");
-      
+
       // Create the Payload
       String data = "This object will be public for 10 minutes.";
       ByteSource source = ByteSource.wrap(data.getBytes());
       Payload payload = Payloads.newByteSourcePayload(source);
-      
+
       // Create the Blob
       Blob blob = blobStore.blobBuilder(FILENAME).payload(payload).contentType("text/plain").build();
       HttpRequest request = blobStoreContext.getSigner().signPutBlob(CONTAINER, blob, TEN_MINUTES);
-      
+
       System.out.format("  %s %s%n", request.getMethod(), request.getEndpoint());
-      
+
       // PUT the file using jclouds
       HttpResponse response = blobStoreContext.utils().http().invoke(request);
       int statusCode = response.getStatusCode();
-      
+
       if (statusCode >= 200 && statusCode < 299) {
          System.out.format("  PUT Success (%s)%n", statusCode);
       }
@@ -120,11 +120,11 @@ public class GenerateTempURL implements Closeable {
 
    private void generateGetTempURL() throws IOException {
       System.out.format("Generate GET Temp URL%n");
-      
+
       HttpRequest request = blobStoreContext.getSigner().signGetBlob(CONTAINER, FILENAME, TEN_MINUTES);
-      
+
       System.out.format("  %s %s%n", request.getMethod(), request.getEndpoint());
-      
+
       // GET the file using jclouds
       File file = File.createTempFile(FILENAME, ".tmp");
       Payload payload = blobStoreContext.utils().http().invoke(request).getPayload();
@@ -141,15 +141,15 @@ public class GenerateTempURL implements Closeable {
 
    private void generateDeleteTempURL() throws IOException {
       System.out.format("Generate DELETE Temp URL%n");
-      
+
       HttpRequest request = blobStoreContext.getSigner().signRemoveBlob(CONTAINER, FILENAME);
-      
+
       System.out.format("  %s %s%n", request.getMethod(), request.getEndpoint());
-      
+
       // DELETE the file using jclouds
       HttpResponse response = blobStoreContext.utils().http().invoke(request);
       int statusCode = response.getStatusCode();
-      
+
       if (statusCode >= 200 && statusCode < 299) {
          System.out.format("  DELETE Success (%s)", statusCode);
       }

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/GetContainer.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/GetContainer.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -39,7 +39,7 @@ public class GetContainer implements Closeable {
 
    /**
     * To get a username and API key see http://jclouds.apache.org/guides/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/GetObject.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/GetObject.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -35,16 +35,16 @@ import com.google.common.io.Closeables;
 
 /**
  * Gets an object from a container and displays the results.
- * 
+ *
  * NOTE: Run the {@link UploadObjects} example prior to running this example.
- *  
+ *
  */
 public class GetObject implements Closeable {
    private final CloudFilesApi cloudFiles;
 
    /**
     * To get a username and API key see http://jclouds.apache.org/guides/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -66,7 +66,7 @@ public class GetObject implements Closeable {
       cloudFiles = ContextBuilder.newBuilder(PROVIDER)
             .credentials(username, apiKey)
             .buildApi(CloudFilesApi.class);
-      
+
    }
 
    private void getObject() {

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/ListContainers.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/ListContainers.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -33,14 +33,14 @@ import com.google.common.io.Closeables;
 
 /**
  * List the Cloud Files containers associated with your account.
- *  
+ *
  */
 public class ListContainers implements Closeable {
    private final CloudFilesApi cloudFiles;
 
    /**
     * To get a username and API key see http://jclouds.apache.org/guides/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/ListObjects.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/ListObjects.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -36,14 +36,14 @@ import com.google.common.io.Closeables;
 
 /**
  * List objects in the Cloud Files container from the CreateContainer example.
- *  
+ *
  */
 public class ListObjects implements Closeable {
    private final CloudFilesApi cloudFiles;
 
    /**
     * To get a username and API key see http://jclouds.apache.org/guides/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/UploadDirectoryToCDN.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/UploadDirectoryToCDN.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -58,7 +58,7 @@ import static org.jclouds.openstack.swift.v1.reference.SwiftHeaders.STATIC_WEB_I
 /**
  * Upload an entire directory and all of its sub-directories to a Cloud Files container. The local directory hierarchy
  * will be mimicked as pseudo-hierarchical directories (http://j.mp/rax-hier) within the container. This is a great
- * way to upload content for a static website (http://j.mp/rax-static).     
+ * way to upload content for a static website (http://j.mp/rax-static).
  */
 public class UploadDirectoryToCDN implements Closeable {
    private static final int THREADS = Integer.getInteger("upload.threadpool.size", 10);
@@ -137,13 +137,13 @@ public class UploadDirectoryToCDN implements Closeable {
    private void uploadFiles(String container, List<BlobDetail> blobDetails)
          throws InterruptedException, ExecutionException {
       ListeningExecutorService executor = MoreExecutors.listeningDecorator(newFixedThreadPool(THREADS));
-      List<ListenableFuture<BlobDetail>> blobUploaderFutures = Lists.newArrayList();      
+      List<ListenableFuture<BlobDetail>> blobUploaderFutures = Lists.newArrayList();
       BlobUploaderCallback blobUploaderCallback = new BlobUploaderCallback();
 
       try {
 
          for (BlobDetail blobDetail: blobDetails) {
-            BlobUploader blobUploader = new BlobUploader(container, blobDetail);         
+            BlobUploader blobUploader = new BlobUploader(container, blobDetail);
             ListenableFuture<BlobDetail> blobDetailFuture = executor.submit(blobUploader);
             blobUploaderFutures.add(blobDetailFuture);
 
@@ -228,7 +228,7 @@ public class UploadDirectoryToCDN implements Closeable {
     * the user of upload progress.
     */
    private class BlobUploaderCallback implements FutureCallback<BlobDetail> {
-      
+
       public void onSuccess(BlobDetail result) {
          System.out.format(".");
       }
@@ -239,7 +239,7 @@ public class UploadDirectoryToCDN implements Closeable {
    }
 
    /**
-    * An immutable class for holding details about an object. When an object has been successfully uploaded the 
+    * An immutable class for holding details about an object. When an object has been successfully uploaded the
     * eTag will be present.
     */
    public static class BlobDetail {

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/UploadLargeObject.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/UploadLargeObject.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -48,7 +48,7 @@ public class UploadLargeObject implements Closeable {
 
    /**
     * To get a username and API key see http://jclouds.apache.org/guides/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     * The third argument (args[2]) must be the absolute path to a large file
@@ -83,9 +83,9 @@ public class UploadLargeObject implements Closeable {
 
    /**
     * Upload a large object from a File using the BlobStore API.
-    * 
-    * @throws ExecutionException 
-    * @throws InterruptedException 
+    *
+    * @throws ExecutionException
+    * @throws InterruptedException
     */
    private void uploadLargeObjectFromFile(File largeFile) throws InterruptedException, ExecutionException {
       System.out.format("Upload Large Object From File%n");

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/UploadObjects.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudfiles/UploadObjects.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -43,7 +43,7 @@ import com.google.common.io.Files;
 
 /**
  * Upload objects in the Cloud Files container from the CreateContainer example.
- *  
+ *
  */
 public class UploadObjects implements Closeable {
    private final BlobStore blobStore;
@@ -51,7 +51,7 @@ public class UploadObjects implements Closeable {
 
    /**
     * To get a username and API key see http://jclouds.apache.org/guides/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -79,7 +79,7 @@ public class UploadObjects implements Closeable {
    }
 
    /**
-    * Upload an object from a File using the Swift API. 
+    * Upload an object from a File using the Swift API.
     */
    private void uploadObjectFromFile() throws IOException {
       System.out.format("Upload Object From File%n");
@@ -105,7 +105,7 @@ public class UploadObjects implements Closeable {
    }
 
    /**
-    * Upload an object from a String using the Swift API. 
+    * Upload an object from a String using the Swift API.
     */
    private void uploadObjectFromString() {
       System.out.format("Upload Object From String%n");
@@ -121,7 +121,7 @@ public class UploadObjects implements Closeable {
    }
 
    /**
-    * Upload an object from a String with metadata using the BlobStore API. 
+    * Upload an object from a String with metadata using the BlobStore API.
     */
    private void uploadObjectFromStringWithMetadata() {
       System.out.format("Upload Object From String With Metadata%n");

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudloadbalancers/AddNodes.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudloadbalancers/AddNodes.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -41,8 +41,8 @@ import static org.jclouds.rackspace.cloudloadbalancers.v1.domain.internal.BaseNo
 import static org.jclouds.rackspace.cloudloadbalancers.v1.domain.internal.BaseNode.Condition.ENABLED;
 
 /**
- * This example adds a Node to a Load Balancer. 
- *  
+ * This example adds a Node to a Load Balancer.
+ *
  */
 public class AddNodes implements Closeable {
    private final CloudLoadBalancersApi clbApi;
@@ -50,7 +50,7 @@ public class AddNodes implements Closeable {
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -83,13 +83,13 @@ public class AddNodes implements Closeable {
             return loadBalancer;
          }
       }
-      
+
       throw new RuntimeException(NAME + " not found. Run a CreateLoadBalancer* example first.");
    }
 
    /**
     * AddNodes are the nodes (Cloud Servers) that receive requests sent from the Load Balancer.
-    * 
+    *
     * The IPv4 addresses in the AddNodes below are only *examples* of addresses that you would use when creating
     * a Load Balancer. You would do this if you had existing Cloud Servers and stored their IPv4
     * addresses as configuration data.
@@ -101,7 +101,7 @@ public class AddNodes implements Closeable {
             .port(80)
             .weight(20)
             .build();
-      
+
       AddNode addNode12 = AddNode.builder()
             .address("10.180.1.2")
             .condition(ENABLED)
@@ -109,38 +109,38 @@ public class AddNodes implements Closeable {
             .weight(20)
             .build();
 
-      return Sets.newHashSet(addNode11, addNode12);      
+      return Sets.newHashSet(addNode11, addNode12);
    }
 
    /**
-    * If you try to visit the IPv4 address of the Load Balancer itself, you will see a "Service Unavailable" message 
+    * If you try to visit the IPv4 address of the Load Balancer itself, you will see a "Service Unavailable" message
     * because the nodes from the createNodeRequests() don't really exist.
-    * 
-    * To see an example of creating Cloud Servers and a Load Balancer at the same time see 
-    * CreateLoadBalancerWithNewServers.  
+    *
+    * To see an example of creating Cloud Servers and a Load Balancer at the same time see
+    * CreateLoadBalancerWithNewServers.
     */
    private void addNodesToLoadBalancer(Set<AddNode> addNodes, LoadBalancer loadBalancer) throws TimeoutException {
       System.out.format("Add Nodes%n");
 
       NodeApi nodeApi = clbApi.getNodeApiForZoneAndLoadBalancer(ZONE, loadBalancer.getId());
       Set<Node> nodes = nodeApi.add(addNodes);
-      
+
       // Wait for the Load Balancer to become Active before moving on
       // If you want to know what's happening during the polling, enable logging. See
       // /jclouds-example/rackspace/src/main/java/org/jclouds/examples/rackspace/Logging.java
       if (!LoadBalancerPredicates.awaitAvailable(lbApi).apply(loadBalancer)) {
-         throw new TimeoutException("Timeout on loadBalancer: " + loadBalancer);     
+         throw new TimeoutException("Timeout on loadBalancer: " + loadBalancer);
       }
-      
-      for (Node node: nodes) {         
+
+      for (Node node: nodes) {
          System.out.format("  %s%n", node);
       }
    }
 
    /**
     * Always close your service when you're done with it.
-    * 
-    * Note that closing quietly like this is not necessary in Java 7. 
+    *
+    * Note that closing quietly like this is not necessary in Java 7.
     * You would use try-with-resources in the main method instead.
     */
    public void close() throws IOException {

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudloadbalancers/Constants.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudloadbalancers/Constants.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudloadbalancers/CreateLoadBalancerWithExistingServers.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudloadbalancers/CreateLoadBalancerWithExistingServers.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -39,8 +39,8 @@ import static org.jclouds.rackspace.cloudloadbalancers.v1.domain.internal.BaseLo
 import static org.jclouds.rackspace.cloudloadbalancers.v1.domain.internal.BaseNode.Condition.ENABLED;
 
 /**
- * This example creates a Load Balancer with existing Cloud Servers on the Rackspace Cloud. 
- *  
+ * This example creates a Load Balancer with existing Cloud Servers on the Rackspace Cloud.
+ *
  */
 public class CreateLoadBalancerWithExistingServers implements Closeable {
    private final CloudLoadBalancersApi clbApi;
@@ -48,7 +48,7 @@ public class CreateLoadBalancerWithExistingServers implements Closeable {
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -73,10 +73,10 @@ public class CreateLoadBalancerWithExistingServers implements Closeable {
             .buildApi(CloudLoadBalancersApi.class);
       lbApi = clbApi.getLoadBalancerApiForZone(ZONE);
    }
-   
+
    /**
     * AddNodes specify the nodes (Cloud Servers) that requests will be sent to by the Load Balancer.
-    * 
+    *
     * The IPv4 addresses in the NodeRequests below are only *examples* of addresses that you would use when creating
     * a Load Balancer. You would do this if you had existing Cloud Servers and stored their IPv4
     * addresses as configuration data.
@@ -88,22 +88,22 @@ public class CreateLoadBalancerWithExistingServers implements Closeable {
             .port(80)
             .weight(20)
             .build();
-      
+
       AddNode addNode02 = AddNode.builder()
             .address("10.180.0.2")
             .condition(ENABLED)
             .port(80)
             .weight(10)
             .build();
-      
-      return Sets.newHashSet(addNode01, addNode02);      
+
+      return Sets.newHashSet(addNode01, addNode02);
    }
 
    /**
-    * If you try to visit the IPv4 address of the Load Balancer itself, you will see a "Service Unavailable" message 
+    * If you try to visit the IPv4 address of the Load Balancer itself, you will see a "Service Unavailable" message
     * because the nodes from the createNodeRequests() don't really exist.
-    * 
-    * To see an example of creating Cloud Servers and a Load Balancer at the same time see 
+    *
+    * To see an example of creating Cloud Servers and a Load Balancer at the same time see
     * CreateLoadBalancerWithNewServers.
     */
    private void createLoadBalancer(Set<AddNode> addNodes) throws TimeoutException {
@@ -117,20 +117,20 @@ public class CreateLoadBalancerWithExistingServers implements Closeable {
             .nodes(addNodes)
             .virtualIPType(PUBLIC)
             .build();
-      
+
       LoadBalancer loadBalancer = lbApi.create(createLB);
-      
+
       // Wait for the Load Balancer to become Active before moving on
       // If you want to know what's happening during the polling, enable logging. See
       // /jclouds-example/rackspace/src/main/java/org/jclouds/examples/rackspace/Logging.java
       if (!LoadBalancerPredicates.awaitAvailable(lbApi).apply(loadBalancer)) {
-         throw new TimeoutException("Timeout on loadBalancer: " + loadBalancer);     
+         throw new TimeoutException("Timeout on loadBalancer: " + loadBalancer);
       }
-      
+
       System.out.format("  %s%n", loadBalancer);
       System.out.format("  Go to http://%s%n", getVirtualIPv4(loadBalancer.getVirtualIPs()));
    }
-   
+
    private String getVirtualIPv4(Set<VirtualIPWithId> set) {
       for (VirtualIPWithId virtualIP: set) {
          if (virtualIP.getType().equals(PUBLIC) &&
@@ -138,14 +138,14 @@ public class CreateLoadBalancerWithExistingServers implements Closeable {
             return virtualIP.getAddress();
          }
       }
-      
+
       throw new RuntimeException("Public IPv4 address not found.");
    }
 
    /**
     * Always close your service when you're done with it.
-    * 
-    * Note that closing quietly like this is not necessary in Java 7. 
+    *
+    * Note that closing quietly like this is not necessary in Java 7.
     * You would use try-with-resources in the main method instead.
     */
    public void close() throws IOException {

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudloadbalancers/CreateLoadBalancerWithNewServers.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudloadbalancers/CreateLoadBalancerWithNewServers.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -41,8 +41,8 @@ import static org.jclouds.rackspace.cloudloadbalancers.v1.domain.internal.BaseLo
 import static org.jclouds.rackspace.cloudloadbalancers.v1.domain.internal.BaseNode.Condition.ENABLED;
 
 /**
- * This example creates a Load Balancer with new Cloud Servers on the Rackspace Cloud. 
- *  
+ * This example creates a Load Balancer with new Cloud Servers on the Rackspace Cloud.
+ *
  */
 public class CreateLoadBalancerWithNewServers implements Closeable {
    private final CloudLoadBalancersApi clbApi;
@@ -50,7 +50,7 @@ public class CreateLoadBalancerWithNewServers implements Closeable {
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -85,29 +85,29 @@ public class CreateLoadBalancerWithNewServers implements Closeable {
     */
    private Set<AddNode> createNodeRequests(Set<? extends NodeMetadata> nodes) {
       Set<AddNode> addNodes = Sets.newHashSet();
-      
+
       for (NodeMetadata node: nodes) {
          String privateAddress = node.getPrivateAddresses().iterator().next();
-         
+
          AddNode addNode = AddNode.builder()
                .address(privateAddress)
                .condition(ENABLED)
                .port(80)
                .weight(20)
                .build();
-         
+
          addNodes.add(addNode);
       }
-      
+
       return addNodes;
    }
 
    /**
     * Create a Load Balancer that randomly distributes requests to its nodes. Normally you will want to use a
     * different algorithm for your Load Balancers (see LoadBalancer.Algorithm) but random nicely demonstrates
-    * how requests are sent to diffent nodes when you reload the "Go to" URL printed out in the terminal.   
-    * 
-    * To see an example of creating a Load Balancer with existing Cloud Servers see  
+    * how requests are sent to diffent nodes when you reload the "Go to" URL printed out in the terminal.
+    *
+    * To see an example of creating a Load Balancer with existing Cloud Servers see
     * CreateLoadBalancerWithExistingServers.
     */
    private void createLoadBalancer(Set<AddNode> addNodes) throws TimeoutException {
@@ -121,20 +121,20 @@ public class CreateLoadBalancerWithNewServers implements Closeable {
             .nodes(addNodes)
             .virtualIPType(PUBLIC)
             .build();
-      
+
       LoadBalancer loadBalancer = lbApi.create(createLB);
-      
+
       // Wait for the Load Balancer to become Active before moving on
       // If you want to know what's happening during the polling, enable logging. See
       // /jclouds-example/rackspace/src/main/java/org/jclouds/examples/rackspace/Logging.java
       if (!LoadBalancerPredicates.awaitAvailable(lbApi).apply(loadBalancer)) {
-         throw new TimeoutException("Timeout on loadBalancer: " + loadBalancer);     
+         throw new TimeoutException("Timeout on loadBalancer: " + loadBalancer);
       }
 
       System.out.format("  %s%n", loadBalancer);
       System.out.format("  Go to http://%s%n", getVirtualIPv4(loadBalancer.getVirtualIPs()));
    }
-   
+
    private String getVirtualIPv4(Set<VirtualIPWithId> set) {
       for (VirtualIPWithId virtualIP: set) {
          if (virtualIP.getType().equals(PUBLIC) &&
@@ -142,14 +142,14 @@ public class CreateLoadBalancerWithNewServers implements Closeable {
             return virtualIP.getAddress();
          }
       }
-      
+
       throw new RuntimeException("Public IPv4 address not found.");
    }
 
    /**
     * Always close your service when you're done with it.
-    * 
-    * Note that closing quietly like this is not necessary in Java 7. 
+    *
+    * Note that closing quietly like this is not necessary in Java 7.
     * You would use try-with-resources in the main method instead.
     */
    public void close() throws IOException {

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudloadbalancers/DeleteLoadBalancers.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudloadbalancers/DeleteLoadBalancers.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -32,8 +32,8 @@ import java.util.concurrent.TimeoutException;
 import static org.jclouds.examples.rackspace.cloudloadbalancers.Constants.*;
 
 /**
- * This example deletes Load Balancers. 
- *  
+ * This example deletes Load Balancers.
+ *
  */
 public class DeleteLoadBalancers implements Closeable {
    private final CloudLoadBalancersApi clbApi;
@@ -41,7 +41,7 @@ public class DeleteLoadBalancers implements Closeable {
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -71,7 +71,7 @@ public class DeleteLoadBalancers implements Closeable {
     */
    private void deleteLoadBalancers() throws TimeoutException {
       System.out.format("Delete Load Balancers%n");
-      
+
       for (LoadBalancer loadBalancer: lbApi.list().concat()) {
          if (loadBalancer.getName().startsWith(NAME)) {
             lbApi.delete(loadBalancer.getId());
@@ -80,18 +80,18 @@ public class DeleteLoadBalancers implements Closeable {
             // If you want to know what's happening during the polling, enable logging. See
             // /jclouds-example/rackspace/src/main/java/org/jclouds/examples/rackspace/Logging.java
             if (!LoadBalancerPredicates.awaitDeleted(lbApi).apply(loadBalancer)) {
-               throw new TimeoutException("Timeout on loadBalancer: " + loadBalancer);     
+               throw new TimeoutException("Timeout on loadBalancer: " + loadBalancer);
             }
 
             System.out.format("  %s%n", loadBalancer);
          }
-      }         
+      }
    }
 
    /**
     * Always close your service when you're done with it.
-    * 
-    * Note that closing quietly like this is not necessary in Java 7. 
+    *
+    * Note that closing quietly like this is not necessary in Java 7.
     * You would use try-with-resources in the main method instead.
     */
    public void close() throws IOException {

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudloadbalancers/ListLoadBalancers.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudloadbalancers/ListLoadBalancers.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -30,15 +30,15 @@ import java.io.IOException;
 import static org.jclouds.examples.rackspace.cloudloadbalancers.Constants.PROVIDER;
 
 /**
- * This example lists all Load Balancers. 
- *  
+ * This example lists all Load Balancers.
+ *
  */
 public class ListLoadBalancers implements Closeable {
    private final CloudLoadBalancersApi clbApi;
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -64,22 +64,22 @@ public class ListLoadBalancers implements Closeable {
 
    private void listLoadBalancers() {
       System.out.format("List Load Balancers%n");
-      
+
       for (String zone: clbApi.getConfiguredZones()) {
          System.out.format("  %s%n", zone);
-         
+
          LoadBalancerApi lbApi = clbApi.getLoadBalancerApiForZone(zone);
-         
+
          for (LoadBalancer loadBalancer: lbApi.list().concat()) {
             System.out.format("    %s%n", loadBalancer);
-         }         
+         }
       }
    }
 
    /**
     * Always close your service when you're done with it.
-    * 
-    * Note that closing quietly like this is not necessary in Java 7. 
+    *
+    * Note that closing quietly like this is not necessary in Java 7.
     * You would use try-with-resources in the main method instead.
     */
    public void close() throws IOException {

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudloadbalancers/RemoveNodes.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudloadbalancers/RemoveNodes.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -38,8 +38,8 @@ import java.util.concurrent.TimeoutException;
 import static org.jclouds.examples.rackspace.cloudloadbalancers.Constants.*;
 
 /**
- * This example removes a Node from a Load Balancer. 
- *  
+ * This example removes a Node from a Load Balancer.
+ *
  */
 public class RemoveNodes implements Closeable {
    private final CloudLoadBalancersApi clbApi;
@@ -47,7 +47,7 @@ public class RemoveNodes implements Closeable {
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -80,20 +80,20 @@ public class RemoveNodes implements Closeable {
             return loadBalancer;
          }
       }
-      
+
       throw new RuntimeException(NAME + " not found. Run a CreateLoadBalancer* example first.");
    }
-   
+
    private Set<Node> getNodes(LoadBalancer loadBalancer) {
       NodeApi nodeApi = clbApi.getNodeApiForZoneAndLoadBalancer(ZONE, loadBalancer.getId());
       Set<Node> nodes = Sets.newHashSet();
-      
+
       for (Node node: nodeApi.list().concat()) {
          if (node.getAddress().startsWith("10.180.1")) {
             nodes.add(node);
          }
       }
-      
+
       return nodes;
    }
 
@@ -102,19 +102,19 @@ public class RemoveNodes implements Closeable {
 
       NodeApi nodeApi = clbApi.getNodeApiForZoneAndLoadBalancer(ZONE, loadBalancer.getId());
       Iterable<Integer> nodeIds = Iterables.transform(nodes, new NodeToId());
-      
+
       nodeApi.remove(nodeIds);
 
       // Wait for the Load Balancer to become Active before moving on
       // If you want to know what's happening during the polling, enable logging. See
       // /jclouds-example/rackspace/src/main/java/org/jclouds/examples/rackspace/Logging.java
       if (!LoadBalancerPredicates.awaitAvailable(lbApi).apply(loadBalancer)) {
-         throw new TimeoutException("Timeout on loadBalancer: " + loadBalancer);     
+         throw new TimeoutException("Timeout on loadBalancer: " + loadBalancer);
       }
-      
+
       System.out.format("  %s%n", nodeIds);
    }
-   
+
    private static class NodeToId implements Function<Node, Integer> {
       @Override
       public Integer apply(Node node) {
@@ -124,8 +124,8 @@ public class RemoveNodes implements Closeable {
 
    /**
     * Always close your service when you're done with it.
-    * 
-    * Note that closing quietly like this is not necessary in Java 7. 
+    *
+    * Note that closing quietly like this is not necessary in Java 7.
     * You would use try-with-resources in the main method instead.
     */
    public void close() throws IOException {

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudloadbalancers/UpdateLoadBalancers.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudloadbalancers/UpdateLoadBalancers.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -34,8 +34,8 @@ import static org.jclouds.examples.rackspace.cloudloadbalancers.Constants.*;
 import static org.jclouds.rackspace.cloudloadbalancers.v1.domain.internal.BaseLoadBalancer.Algorithm.RANDOM;
 
 /**
- * This example updates a Load Balancer. 
- *  
+ * This example updates a Load Balancer.
+ *
  */
 public class UpdateLoadBalancers implements Closeable {
    private final CloudLoadBalancersApi clbApi;
@@ -43,7 +43,7 @@ public class UpdateLoadBalancers implements Closeable {
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -75,7 +75,7 @@ public class UpdateLoadBalancers implements Closeable {
             return loadBalancer;
          }
       }
-      
+
       throw new RuntimeException(NAME + " not found. Run a CreateLoadBalancer* example first.");
    }
 
@@ -88,14 +88,14 @@ public class UpdateLoadBalancers implements Closeable {
             .port(443)
             .algorithm(RANDOM)
             .build();
-      
+
       lbApi.update(loadBalancer.getId(), updateLB);
 
       // Wait for the Load Balancer to become Active before moving on
       // If you want to know what's happening during the polling, enable logging. See
       // /jclouds-example/rackspace/src/main/java/org/jclouds/examples/rackspace/Logging.java
       if (!LoadBalancerPredicates.awaitAvailable(lbApi).apply(loadBalancer)) {
-         throw new TimeoutException("Timeout on loadBalancer: " + loadBalancer);     
+         throw new TimeoutException("Timeout on loadBalancer: " + loadBalancer);
       }
 
       System.out.format("  %s%n", true);
@@ -103,8 +103,8 @@ public class UpdateLoadBalancers implements Closeable {
 
    /**
     * Always close your service when you're done with it.
-    * 
-    * Note that closing quietly like this is not necessary in Java 7. 
+    *
+    * Note that closing quietly like this is not necessary in Java 7.
     * You would use try-with-resources in the main method instead.
     */
    public void close() throws IOException {

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudloadbalancers/UpdateNodes.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudloadbalancers/UpdateNodes.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -39,8 +39,8 @@ import static org.jclouds.rackspace.cloudloadbalancers.v1.domain.internal.BaseNo
 import static org.jclouds.rackspace.cloudloadbalancers.v1.domain.internal.BaseNode.Condition.ENABLED;
 
 /**
- * This example updates Nodes in a Load Balancer. 
- *  
+ * This example updates Nodes in a Load Balancer.
+ *
  */
 public class UpdateNodes implements Closeable {
    private final CloudLoadBalancersApi clbApi;
@@ -48,7 +48,7 @@ public class UpdateNodes implements Closeable {
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -81,20 +81,20 @@ public class UpdateNodes implements Closeable {
             return loadBalancer;
          }
       }
-      
+
       throw new RuntimeException(NAME + " not found. Run a CreateLoadBalancer* example first.");
    }
-   
+
    private Set<Node> getNodes(LoadBalancer loadBalancer) {
       NodeApi nodeApi = clbApi.getNodeApiForZoneAndLoadBalancer(ZONE, loadBalancer.getId());
       Set<Node> nodes = Sets.newHashSet();
-      
+
       for (Node node: nodeApi.list().concat()) {
          if (node.getCondition().equals(DISABLED)) {
             nodes.add(node);
          }
       }
-      
+
       return nodes;
    }
 
@@ -107,7 +107,7 @@ public class UpdateNodes implements Closeable {
             .weight(20)
             .build();
 
-      for (Node node: nodes) {         
+      for (Node node: nodes) {
          nodeApi.update(node.getId(), updateNode);
          System.out.format("  %s %s%n", node.getId(), updateNode);
       }
@@ -116,14 +116,14 @@ public class UpdateNodes implements Closeable {
       // If you want to know what's happening during the polling, enable logging. See
       // /jclouds-example/rackspace/src/main/java/org/jclouds/examples/rackspace/Logging.java
       if (!LoadBalancerPredicates.awaitAvailable(lbApi).apply(loadBalancer)) {
-         throw new TimeoutException("Timeout on loadBalancer: " + loadBalancer);     
+         throw new TimeoutException("Timeout on loadBalancer: " + loadBalancer);
       }
    }
 
    /**
     * Always close your service when you're done with it.
-    * 
-    * Note that closing quietly like this is not necessary in Java 7. 
+    *
+    * Note that closing quietly like this is not necessary in Java 7.
     * You would use try-with-resources in the main method instead.
     */
    public void close() throws IOException {

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudqueues/Constants.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudqueues/Constants.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudqueues/ProducerConsumer.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudqueues/ProducerConsumer.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudqueues/PublishSubscribe.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudqueues/PublishSubscribe.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudqueues/StreamMessages.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudqueues/StreamMessages.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudservers/CloudServersPublish.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudservers/CloudServersPublish.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -61,8 +61,8 @@ public class CloudServersPublish implements Closeable {
    /**
     * To get a username and API key see
     * http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
-    * The first argument (args[0]) must be your username 
+    *
+    * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     * The optional third argument (args[2]) is the number of Cloud Servers to start
     */
@@ -73,11 +73,11 @@ public class CloudServersPublish implements Closeable {
    public static Set<? extends NodeMetadata> getPublishedCloudServers(List<String> args) throws IOException {
       CloudServersPublish cloudServersPublish = new CloudServersPublish(args);
       Set<? extends NodeMetadata> nodes = null;
-      
+
       try {
          nodes = cloudServersPublish.createServer();
          cloudServersPublish.configureAndStartWebserver(nodes);
-         
+
          return nodes;
       }
       catch (Exception e) {
@@ -86,7 +86,7 @@ public class CloudServersPublish implements Closeable {
       finally {
          cloudServersPublish.close();
       }
-      
+
       return nodes;
    }
 

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudservers/Constants.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudservers/Constants.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudservers/CreateServer.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudservers/CreateServer.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -40,14 +40,14 @@ import static org.jclouds.examples.rackspace.cloudservers.Constants.*;
 
 /**
  * This example creates an Ubuntu 12.04 server with 1024 MB of RAM on the Rackspace Cloud.
- *  
+ *
  */
 public class CreateServer implements Closeable {
    private final ComputeService computeService;
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -82,7 +82,7 @@ public class CreateServer implements Closeable {
     * Create a server based on a Template. This method uses Template.fromHardware() and Template.fromImage() to
     * also demonstrate iterating through Hardware and Images. Alternatively you do the same without iterating
     * using the following Template.
-    * 
+    *
     * Template template = computeService.templateBuilder()
     *     .locationId(getLocationId())
     *     .osFamily(OsFamily.UBUNTU)
@@ -114,7 +114,7 @@ public class CreateServer implements Closeable {
 
    /**
     * This method uses the generic ComputeService.listHardwareProfiles() to find the hardware profile.
-    * 
+    *
     * @return The Hardware with 1024 MB of RAM
     */
    private Hardware getHardware() {
@@ -140,8 +140,8 @@ public class CreateServer implements Closeable {
 
    /**
     * This method uses the generic ComputeService.listImages() to find the image.
-    * 
-    * @return An Ubuntu 12.04 Image 
+    *
+    * @return An Ubuntu 12.04 Image
     */
    private Image getImage() {
       System.out.format("  Images%n");

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudservers/CreateServerWithKeyPair.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudservers/CreateServerWithKeyPair.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudservers/DeleteServer.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudservers/DeleteServer.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -35,15 +35,15 @@ import static org.jclouds.compute.predicates.NodePredicates.inGroup;
 import static org.jclouds.examples.rackspace.cloudservers.Constants.*;
 
 /**
- * This example destroys the server created in the CreateServer example. 
- *  
+ * This example destroys the server created in the CreateServer example.
+ *
  */
 public class DeleteServer implements Closeable {
    private ComputeService computeService;
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudservers/ListServersWithFiltering.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudservers/ListServersWithFiltering.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -37,7 +37,7 @@ import static org.jclouds.examples.rackspace.cloudservers.Constants.ZONE;
 
 /**
  * This example lists servers filtered by Predicates. Run the CreateServer example before this to get some results.
- *  
+ *
  */
 public class ListServersWithFiltering implements Closeable {
    private final ComputeService computeService;
@@ -45,7 +45,7 @@ public class ListServersWithFiltering implements Closeable {
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */

--- a/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudservers/ServerMetadata.java
+++ b/rackspace/src/main/java/org/jclouds/examples/rackspace/cloudservers/ServerMetadata.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -41,7 +41,7 @@ import com.google.common.io.Closeables;
 
 /**
  * This example sets, gets, updates, and deletes metadata from a server.
- *  
+ *
  */
 public class ServerMetadata implements Closeable {
    private final ComputeService computeService;
@@ -50,7 +50,7 @@ public class ServerMetadata implements Closeable {
 
    /**
     * To get a username and API key see http://www.jclouds.org/documentation/quickstart/rackspace/
-    * 
+    *
     * The first argument (args[0]) must be your username
     * The second argument (args[1]) must be your API key
     */
@@ -100,8 +100,8 @@ public class ServerMetadata implements Closeable {
       System.out.format("Set Metadata%n");
 
       ImmutableMap<String, String> metadata = ImmutableMap.<String, String> of(
-            "key1", "value1", 
-            "key2", "value2", 
+            "key1", "value1",
+            "key2", "value2",
             "key3", "value3");
       Map<String, String> responseMetadata = serverApi.setMetadata(server.getId(), metadata);
 


### PR DESCRIPTION
I recently set my editor to remove trailing whitespaces, because it's frowned upon by most style guides. Some IDEs or formatters remove white space, and others ignore them... but I don't know of any that introduce trailing whitespace. So preemptively removing trailing whitespace avoids noisy diffs later.

I also tried out the [maven java formatter](http://maven-java-formatter-plugin.googlecode.com/svn/site/0.4/usage.html), but it made more substantial changes that might conflict with IDE settings. It might still be a good idea if there's a standard jclouds formatter configuration it can use.

Also, I only made these changes on the rackspace folder. If you want to update the rest, I used this command on OSX:
`find . -name \*.java | xargs -L1 sed -i "" 's/[ ]*$//'`
