### PR TITLE
Added Google Cloud Storage parameterization to blobstore_basics

### DIFF
--- a/blobstore-basics/README.md
+++ b/blobstore-basics/README.md
@@ -22,7 +22,7 @@ For IBM SoftLayer ObjectStore in `ams01`
 
     java -Djclouds.keystone.credential-type=tempAuthCredentials -Djclouds.endpoint=https://ams01.objectstorage.softlayer.net/auth/v1.0/ -jar target/blobstore-basics-jar-with-dependencies.jar openstack-swift username apikey myfavoritecontainer https://ams01.objectstorage.softlayer.net/auth/v1.0/
   
-For Google Compute Storage
+For Google Cloud Storage
 
     java -jar target/blobstore-basics-jar-with-dependencies.jar \
          google-cloud-storage \

--- a/blobstore-basics/README.md
+++ b/blobstore-basics/README.md
@@ -22,7 +22,7 @@ For IBM SoftLayer ObjectStore in `ams01`
 
     java -Djclouds.keystone.credential-type=tempAuthCredentials -Djclouds.endpoint=https://ams01.objectstorage.softlayer.net/auth/v1.0/ -jar target/blobstore-basics-jar-with-dependencies.jar openstack-swift username apikey myfavoritecontainer https://ams01.objectstorage.softlayer.net/auth/v1.0/
   
-Google Compute Storage provider
+For Google Compute Storage
 
     java -jar target/blobstore-basics-jar-with-dependencies.jar \
          google-cloud-storage \

--- a/blobstore-basics/README.md
+++ b/blobstore-basics/README.md
@@ -21,6 +21,15 @@ For Rackspace CloudFiles
 For IBM SoftLayer ObjectStore in `ams01`
 
     java -Djclouds.keystone.credential-type=tempAuthCredentials -Djclouds.endpoint=https://ams01.objectstorage.softlayer.net/auth/v1.0/ -jar target/blobstore-basics-jar-with-dependencies.jar openstack-swift username apikey myfavoritecontainer https://ams01.objectstorage.softlayer.net/auth/v1.0/
+  
+Google Compute Storage provider
+
+    java -jar target/blobstore-basics-jar-with-dependencies.jar \
+         google-cloud-storage \
+         your-project-service-account-email@developer.gserviceaccount.com \
+         /path/to/json-key.json \
+         myfavoritecontainer
+
 
 ## License
 


### PR DESCRIPTION
Modified blobstore-basics to expect a json key file as the credential when provider is google-cloud-storage, and, in that case, extract the private key from the json file. This is consistent with the compute-basics example
Added documentation on GCS parameterization to the README.md